### PR TITLE
sfneal/actions v2.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,3 +82,8 @@ All notable changes to `models` will be documented in this file
 ## 1.3.0 - 2021-03-24
 - make `ResolveModelName` action with tests for retrieving a model's name for use in logging 
 - add composer requiring of sfneal/string-helpers (min version 1.1.4) to support use of `camelCaseSplit()` method
+
+
+## 1.4.0 - 2021-03-31
+- add sfneal/actions (^2.0) to composer requirements
+- refactor `AbstractAction` extension to `Action`

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.3",
+        "sfneal/actions": "^2.0",
         "sfneal/builders": ">=1.0",
         "sfneal/string-helpers": ">=1.1.4",
         "sfneal/laravel-helpers": ">=1.0",

--- a/src/Actions/ResolveModelName.php
+++ b/src/Actions/ResolveModelName.php
@@ -2,12 +2,12 @@
 
 namespace Sfneal\Models\Actions;
 
-use Sfneal\Actions\AbstractAction;
+use Sfneal\Actions\Action;
 use Sfneal\Helpers\Laravel\LaravelHelpers;
 use Sfneal\Helpers\Strings\StringHelpers;
 use Sfneal\Models\AbstractModel;
 
-class ResolveModelName extends AbstractAction
+class ResolveModelName extends Action
 {
     /**
      * @var AbstractModel


### PR DESCRIPTION
- add sfneal/actions (^2.0) to composer requirements
- refactor `AbstractAction` extension to `Action`