### PR TITLE
Fix issue with `ResolveModelName` handling class strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,3 +104,7 @@ All notable changes to `models` will be documented in this file
 ## 2.2.0 - 2021-04-08
 - merge sfneal/builders package into sfneal/models package without breaking namespaces
 - cut `Sfneal\Models\Traits\InvalidateModelCache` trait & moved methods to `CacheableAll`
+
+
+## 2.3.0 - 2021-06-10
+- fix issue with `ResolveModelName` action throwing exception when giving a class string instead of an object

--- a/src/Models/Actions/ResolveModelName.php
+++ b/src/Models/Actions/ResolveModelName.php
@@ -10,7 +10,7 @@ use Sfneal\Models\Model;
 class ResolveModelName extends Action
 {
     /**
-     * @var Model
+     * @var Model|string
      */
     private $model;
 
@@ -22,10 +22,10 @@ class ResolveModelName extends Action
     /**
      * ResolveModelName constructor.
      *
-     * @param Model $model
+     * @param Model|string $model
      * @param bool $short
      */
-    public function __construct(Model $model, bool $short = true)
+    public function __construct($model, bool $short = true)
     {
         $this->model = $model;
         $this->short = $short;
@@ -34,9 +34,9 @@ class ResolveModelName extends Action
     /**
      * Retrieve the Model class's short name (without namespace).
      *
-     * @return mixed
+     * @return string
      */
-    public function execute()
+    public function execute(): string
     {
         // Split string on upper case characters
         return implode(' ', (new StringHelpers($this->getClassName()))->camelCaseSplit());
@@ -49,7 +49,11 @@ class ResolveModelName extends Action
      */
     private function getClassName(): string
     {
-        return LaravelHelpers::getClassName($this->model, $this->short, $this->getTableCamelCase());
+        return LaravelHelpers::getClassName(
+            $this->model,
+            $this->short,
+            ! is_string($this->model) ? $this->getTableCamelCase() : null
+        );
     }
 
     /**

--- a/tests/ResolveModelNameTest.php
+++ b/tests/ResolveModelNameTest.php
@@ -4,6 +4,7 @@ namespace Sfneal\Models\Tests;
 
 use Sfneal\Models\Actions\ResolveModelName;
 use Sfneal\Models\Tests\Models\CompanyPeople;
+use Sfneal\Models\Tests\Models\People;
 
 class ResolveModelNameTest extends ModelTestCase
 {
@@ -12,6 +13,16 @@ class ResolveModelNameTest extends ModelTestCase
     {
         $expected = 'People';
         $output = (new ResolveModelName($this->model, true))->execute();
+
+        $this->assertIsString($output);
+        $this->assertEquals($expected, $output);
+    }
+
+    /** @test */
+    public function resolveClassModelName()
+    {
+        $expected = 'People';
+        $output = (new ResolveModelName(People::class, true))->execute();
 
         $this->assertIsString($output);
         $this->assertEquals($expected, $output);


### PR DESCRIPTION
- fix issue with `ResolveModelName` action throwing exception when giving a class string instead of an object