### PR TITLE
`Model` unit test improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,9 @@ All notable changes to `models` will be documented in this file
 ## 2.4.0 - 2021-07-15
 - fix issues with trait & interface declarations in `ModelWithPublicStatus` model
 - make `ModelWithPublicStatusTest` for testing public status traits & interfaces
+
+
+## 2.4.1 - 2021-07-27
+- fix issues with `Model::hasAttribute()` method incorrectly returning true
+- optimize return type hinting in various `Model` methods
+- add test methods to `ModelTest` that test all remaining `Model` methods & properties

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -72,9 +72,9 @@ abstract class Model extends EloquentModel
     /**
      * Determine how new a model instance is by subtracting the current time with the created_at time.
      *
-     * @return false|float
+     * @return float
      */
-    public function howNew()
+    public function howNew(): float
     {
         return round((time() - strtotime($this->created_at)) / (60 * 60 * 24));
     }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -105,7 +105,7 @@ abstract class Model extends EloquentModel
         return
             isset($attr) &&
             array_key_exists($attr, $this->attributesToArray()) &&
-            (!$is_fillable || in_array($attr, $this->getFillable()));
+            (! $is_fillable || in_array($attr, $this->getFillable()));
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -124,7 +124,7 @@ abstract class Model extends EloquentModel
      *
      * @return int
      */
-    public function getIdHashAttribute()
+    public function getIdHashAttribute(): int
     {
         return crc32($this->getKey());
     }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -104,8 +104,8 @@ abstract class Model extends EloquentModel
         // Determine that the attribute exists and optionally weather it is fillable
         return
             isset($attr) &&
-            (bool) $this->{$attr} &&
-            (!$is_fillable || array_key_exists($attr, $this->fillable) || in_array($attr, $this->fillable));
+            array_key_exists($attr, $this->attributesToArray()) &&
+            (!$is_fillable || in_array($attr, $this->getFillable()));
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -130,16 +130,6 @@ abstract class Model extends EloquentModel
     }
 
     /**
-     * Retrieve the 'created_at' attribute mutated to human readable datetime.
-     *
-     * @return string
-     */
-    public function getDatetimeAttribute(): string
-    {
-        return date('Y-m-d h:i a', strtotime($this->created_at));
-    }
-
-    /**
      * Returns the default 'label' for a model instance.
      *
      * @return mixed
@@ -218,15 +208,13 @@ abstract class Model extends EloquentModel
     }
 
     /**
-     * Retrieve the 'updated_at' attribute mutated to timestamp string.
-     *
-     *  - 'updated_timestamp' attribute accessor
+     * Retrieve the 'created_at' attribute mutated to human readable datetime.
      *
      * @return string
      */
-    public function getUpdatedTimestampAttribute(): string
+    public function getDatetimeAttribute(): string
     {
-        return date($this->timestampFormat, strtotime($this->updated_at));
+        return date('Y-m-d h:i a', strtotime($this->created_at));
     }
 
     /**
@@ -239,18 +227,6 @@ abstract class Model extends EloquentModel
     public function getCreatedTimestampAttribute(): string
     {
         return date($this->timestampFormat, strtotime($this->created_at));
-    }
-
-    /**
-     * Retrieve the 'updated_at' attribute mutated to difference for humans string.
-     *
-     *  - 'updated_for_humans' attribute accessor
-     *
-     * @return string
-     */
-    public function getUpdatedForHumansAttribute(): string
-    {
-        return $this->updated_at->diffForHumans();
     }
 
     /**
@@ -283,6 +259,30 @@ abstract class Model extends EloquentModel
     public function getCreatedTimeAttribute(): string
     {
         return date('h:i A', strtotime($this->created_at));
+    }
+
+    /**
+     * Retrieve the 'updated_at' attribute mutated to timestamp string.
+     *
+     *  - 'updated_timestamp' attribute accessor
+     *
+     * @return string
+     */
+    public function getUpdatedTimestampAttribute(): string
+    {
+        return date($this->timestampFormat, strtotime($this->updated_at));
+    }
+
+    /**
+     * Retrieve the 'updated_at' attribute mutated to difference for humans string.
+     *
+     *  - 'updated_for_humans' attribute accessor
+     *
+     * @return string
+     */
+    public function getUpdatedForHumansAttribute(): string
+    {
+        return $this->updated_at->diffForHumans();
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -104,8 +104,8 @@ abstract class Model extends EloquentModel
         // Determine that the attribute exists and optionally weather it is fillable
         return
             isset($attr) &&
-            (bool) $this->$attr &&
-            ($is_fillable ? (array_key_exists($attr, $this->fillable) || in_array($attr, $this->fillable)) : true);
+            (bool) $this->{$attr} &&
+            (!$is_fillable || array_key_exists($attr, $this->fillable) || in_array($attr, $this->fillable));
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -208,6 +208,16 @@ abstract class Model extends EloquentModel
     }
 
     /**
+     * Retrieve the 'timestampFormat' property.
+     *
+     * @return string
+     */
+    public function getTimestampFormat(): string
+    {
+        return $this->timestampFormat;
+    }
+
+    /**
      * Retrieve the 'created_at' attribute mutated to human readable datetime.
      *
      * @return string
@@ -226,7 +236,7 @@ abstract class Model extends EloquentModel
      */
     public function getCreatedTimestampAttribute(): string
     {
-        return date($this->timestampFormat, strtotime($this->created_at));
+        return date($this->getTimestampFormat(), strtotime($this->created_at));
     }
 
     /**
@@ -270,7 +280,7 @@ abstract class Model extends EloquentModel
      */
     public function getUpdatedTimestampAttribute(): string
     {
-        return date($this->timestampFormat, strtotime($this->updated_at));
+        return date($this->getTimestampFormat(), strtotime($this->updated_at));
     }
 
     /**

--- a/tests/ModelTestCase.php
+++ b/tests/ModelTestCase.php
@@ -20,6 +20,6 @@ class ModelTestCase extends TestCase
     {
         parent::setUp();
 
-        $this->model = People::factory()->make();
+        $this->model = People::factory()->create();
     }
 }

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -9,27 +9,6 @@ class ModelTest extends ModelTestCase
     // todo: improve test methods
 
     /** @test */
-    public function hasAttribute()
-    {
-        $this->assertTrue($this->model->hasAttribute('name_first', true));
-        $this->assertTrue($this->model->hasAttribute('name_last', true));
-        $this->assertTrue($this->model->hasAttribute('email', true));
-        $this->assertTrue($this->model->hasAttribute('age', true));
-        $this->assertTrue($this->model->hasAttribute('address', true));
-        $this->assertTrue($this->model->hasAttribute('city', true));
-        $this->assertTrue($this->model->hasAttribute('state', true));
-        $this->assertTrue($this->model->hasAttribute('zip', true));
-        $this->assertTrue($this->model->hasAttribute('public_status', true));
-
-        $this->assertFalse($this->model->hasAttribute('name_full', false));
-        $this->assertFalse($this->model->hasAttribute('name_last_first', false));
-        $this->assertFalse($this->model->hasAttribute('address_full', false));
-        $this->assertFalse($this->model->hasAttribute('address_latest', false));
-        $this->assertFalse($this->model->hasAttribute('name_full_with_suffix', false));
-        $this->assertFalse($this->model->hasAttribute('address_city', false));
-    }
-
-    /** @test */
     public function isNew()
     {
         $this->assertTrue($this->model->isNew());
@@ -49,6 +28,27 @@ class ModelTest extends ModelTestCase
 
         $this->assertIsString($actual);
         $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function hasAttribute()
+    {
+        $this->assertTrue($this->model->hasAttribute('name_first', true));
+        $this->assertTrue($this->model->hasAttribute('name_last', true));
+        $this->assertTrue($this->model->hasAttribute('email', true));
+        $this->assertTrue($this->model->hasAttribute('age', true));
+        $this->assertTrue($this->model->hasAttribute('address', true));
+        $this->assertTrue($this->model->hasAttribute('city', true));
+        $this->assertTrue($this->model->hasAttribute('state', true));
+        $this->assertTrue($this->model->hasAttribute('zip', true));
+        $this->assertTrue($this->model->hasAttribute('public_status', true));
+
+        $this->assertFalse($this->model->hasAttribute('name_full', false));
+        $this->assertFalse($this->model->hasAttribute('name_last_first', false));
+        $this->assertFalse($this->model->hasAttribute('address_full', false));
+        $this->assertFalse($this->model->hasAttribute('address_latest', false));
+        $this->assertFalse($this->model->hasAttribute('name_full_with_suffix', false));
+        $this->assertFalse($this->model->hasAttribute('address_city', false));
     }
 
     /** @test */

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -170,6 +170,94 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function getCreatedTimestampAttribute()
+    {
+        $expected = date($this->model->getTimestampFormat(), strtotime($this->model->created_at));
+        $actual = $this->model->created_timestamp;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getCreatedTimestampAttribute());
+    }
+
+    /** @test */
+    public function getCreatedForHumansAttribute()
+    {
+        $expected = $this->model->created_at->diffForHumans();
+        $actual = $this->model->created_for_humans;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getCreatedForHumansAttribute());
+    }
+
+    /** @test */
+    public function getCreatedDateAttribute()
+    {
+        $expected = date('Y-m-d', strtotime($this->model->created_at));
+        $actual = $this->model->created_date;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getCreatedDateAttribute());
+    }
+
+    /** @test */
+    public function getCreatedTimeAttribute()
+    {
+        $expected = date('h:i A', strtotime($this->model->created_at));
+        $actual = $this->model->created_time;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getCreatedTimeAttribute());
+    }
+
+    /** @test */
+    public function getUpdatedTimestampAttribute()
+    {
+        $expected = date($this->model->getTimestampFormat(), strtotime($this->model->updated_at));
+        $actual = $this->model->updated_timestamp;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getUpdatedTimestampAttribute());
+    }
+
+    /** @test */
+    public function getUpdatedForHumansAttribute()
+    {
+        $expected = $this->model->updated_at->diffForHumans();
+        $actual = $this->model->updated_for_humans;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getUpdatedForHumansAttribute());
+    }
+
+    /** @test */
+    public function getUpdatedDateAttribute()
+    {
+        $expected = date('Y-m-d', strtotime($this->model->updated_at));
+        $actual = $this->model->updated_date;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getUpdatedDateAttribute());
+    }
+
+    /** @test */
+    public function getUpdatedTimeAttribute()
+    {
+        $expected = date('h:i A', strtotime($this->model->updated_at));
+        $actual = $this->model->updated_time;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getUpdatedTimeAttribute());
+    }
+
+    /** @test */
     public function getUploadDirectory()
     {
         $uploadDirectory = $this->model->getUploadDirectory();

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -125,6 +125,16 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function mostRecentChange()
+    {
+        $expected = 'created';
+        $actual = $this->model->mostRecentChange();
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
     public function wasDeleted()
     {
         $notDeleted = $this->model->wasDeleted();

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -66,16 +66,21 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function getIdHashAttribute()
+    {
+        $expected = crc32($this->model->getKey());
+        $actual = $this->model->id_hash;
+
+        $this->assertIsInt($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getIdHashAttribute());
+    }
+
+    /** @test */
     public function getLabel()
     {
         $label = $this->model->getLabel();
         $this->assertSame($label, $this->model->getKey());
-    }
-
-    /** @test */
-    public function idHash()
-    {
-        $this->assertIsInt($this->model->id_hash);
     }
 
     /** @test */

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -160,6 +160,16 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function getTimestampFormat()
+    {
+        $expected = 'Y-m-d h:i a';
+        $actual = $this->model->getTimestampFormat();
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
     public function getUploadDirectory()
     {
         $uploadDirectory = $this->model->getUploadDirectory();

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -21,13 +21,18 @@ class ModelTest extends ModelTestCase
         $this->assertTrue($this->model->hasAttribute('zip', true));
         $this->assertTrue($this->model->hasAttribute('public_status', true));
 
-        $this->assertTrue($this->model->hasAttribute('name_full', false));
-        $this->assertTrue($this->model->hasAttribute('name_last_first', false));
-        $this->assertTrue($this->model->hasAttribute('address_full', false));
-
+        $this->assertFalse($this->model->hasAttribute('name_full', false));
+        $this->assertFalse($this->model->hasAttribute('name_last_first', false));
+        $this->assertFalse($this->model->hasAttribute('address_full', false));
         $this->assertFalse($this->model->hasAttribute('address_latest', false));
         $this->assertFalse($this->model->hasAttribute('name_full_with_suffix', false));
         $this->assertFalse($this->model->hasAttribute('address_city', false));
+    }
+
+    /** @test */
+    public function isNew()
+    {
+        $this->assertTrue($this->model->isNew());
     }
 
     /** @test */

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -125,16 +125,6 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
-    public function mostRecentChange()
-    {
-        $expected = 'created';
-        $actual = $this->model->mostRecentChange();
-
-        $this->assertIsString($actual);
-        $this->assertSame($expected, $actual);
-    }
-
-    /** @test */
     public function wasDeleted()
     {
         $notDeleted = $this->model->wasDeleted();
@@ -146,6 +136,27 @@ class ModelTest extends ModelTestCase
         $deleted = $this->model->wasDeleted();
         $this->assertIsBool($deleted);
         $this->assertTrue($deleted);
+    }
+
+    /** @test */
+    public function mostRecentChange()
+    {
+        $expected = 'created';
+        $actual = $this->model->mostRecentChange();
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function getDatetimeAttribute()
+    {
+        $expected = date('Y-m-d h:i a', strtotime($this->model->created_at));
+        $actual = $this->model->datetime;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getDatetimeAttribute());
     }
 
     /** @test */

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -42,6 +42,16 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function getIsNewColumn()
+    {
+        $expected = 'created_at';
+        $actual = $this->model->getIsNewColumn();
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
     public function getLabel()
     {
         $label = $this->model->getLabel();

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -36,6 +36,12 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function howNew()
+    {
+        $this->assertIsFloat($this->model->howNew());
+    }
+
+    /** @test */
     public function getLabel()
     {
         $label = $this->model->getLabel();

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -6,8 +6,6 @@ use Sfneal\Models\Tests\ModelTestCase;
 
 class ModelTest extends ModelTestCase
 {
-    // todo: improve test methods
-
     /** @test */
     public function isNew()
     {
@@ -260,6 +258,7 @@ class ModelTest extends ModelTestCase
     /** @test */
     public function getUploadDirectory()
     {
+        // todo: refactor to a trait test class
         $uploadDirectory = $this->model->getUploadDirectory();
         $this->assertIsString($uploadDirectory);
         $this->assertTrue($uploadDirectory == "files/{$this->model->getTableName()}/{$this->model->getKey()}");

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -52,6 +52,20 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function hasNullAttribute()
+    {
+        $this->assertFalse($this->model->hasNullAttribute('name_first'));
+        $this->assertFalse($this->model->hasNullAttribute('name_last'));
+        $this->assertFalse($this->model->hasNullAttribute('email'));
+        $this->assertFalse($this->model->hasNullAttribute('age'));
+        $this->assertFalse($this->model->hasNullAttribute('address'));
+        $this->assertFalse($this->model->hasNullAttribute('city'));
+        $this->assertFalse($this->model->hasNullAttribute('state'));
+        $this->assertFalse($this->model->hasNullAttribute('zip'));
+        $this->assertFalse($this->model->hasNullAttribute('public_status'));
+    }
+
+    /** @test */
     public function getLabel()
     {
         $label = $this->model->getLabel();

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -115,7 +115,7 @@ class ModelTest extends ModelTestCase
 
         $this->model->update([
             'name_first' => 'Taylor',
-            'name_last' => 'Hall'
+            'name_last' => 'Hall',
         ]);
         $updated = $this->model->wasUpdated();
         $this->assertIsBool($updated);
@@ -128,7 +128,6 @@ class ModelTest extends ModelTestCase
         $notDeleted = $this->model->wasDeleted();
         $this->assertIsBool($notDeleted);
         $this->assertFalse($notDeleted);
-
 
         $this->model->delete();
         $deleted = $this->model->wasDeleted();

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -12,11 +12,20 @@ class ModelTest extends ModelTestCase
     public function hasAttribute()
     {
         $this->assertTrue($this->model->hasAttribute('name_first', true));
+        $this->assertTrue($this->model->hasAttribute('name_last', true));
+        $this->assertTrue($this->model->hasAttribute('email', true));
+        $this->assertTrue($this->model->hasAttribute('age', true));
         $this->assertTrue($this->model->hasAttribute('address', true));
+        $this->assertTrue($this->model->hasAttribute('city', true));
+        $this->assertTrue($this->model->hasAttribute('state', true));
+        $this->assertTrue($this->model->hasAttribute('zip', true));
+        $this->assertTrue($this->model->hasAttribute('public_status', true));
+
         $this->assertTrue($this->model->hasAttribute('name_full', false));
+        $this->assertTrue($this->model->hasAttribute('name_last_first', false));
         $this->assertTrue($this->model->hasAttribute('address_full', false));
-        $this->assertFalse($this->model->hasAttribute('first_name', true));
-        $this->assertFalse($this->model->hasAttribute('address_latest', true));
+
+        $this->assertFalse($this->model->hasAttribute('address_latest', false));
         $this->assertFalse($this->model->hasAttribute('name_full_with_suffix', false));
         $this->assertFalse($this->model->hasAttribute('address_city', false));
     }

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -100,6 +100,45 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function wasCreated()
+    {
+        $actual = $this->model->wasCreated();
+
+        $this->assertIsBool($actual);
+        $this->assertTrue($actual);
+    }
+
+    /** @test */
+    public function wasUpdated()
+    {
+        $notUpdated = $this->model->wasUpdated();
+        $this->assertIsBool($notUpdated);
+        $this->assertFalse($notUpdated);
+
+        $this->model->update([
+            'name_first' => 'Taylor',
+            'name_last' => 'Hall'
+        ]);
+        $updated = $this->model->wasUpdated();
+        $this->assertIsBool($updated);
+        $this->assertTrue($updated);
+    }
+
+    /** @test */
+    public function wasDeleted()
+    {
+        $notDeleted = $this->model->wasDeleted();
+        $this->assertIsBool($notDeleted);
+        $this->assertFalse($notDeleted);
+
+
+        $this->model->delete();
+        $deleted = $this->model->wasDeleted();
+        $this->assertIsBool($deleted);
+        $this->assertTrue($deleted);
+    }
+
+    /** @test */
     public function getUploadDirectory()
     {
         $uploadDirectory = $this->model->getUploadDirectory();


### PR DESCRIPTION
- fix issues with `Model::hasAttribute()` method incorrectly returning true
- optimize return type hinting in various `Model` methods
- add test methods to `ModelTest` that test all remaining `Model` methods & properties

fixes #14 