### PR TITLE
`Model` timestamp 'human readable' formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,7 @@ All notable changes to `models` will be documented in this file
 ## 2.4.0 - 2021-07-15
 - fix issues with trait & interface declarations in `ModelWithPublicStatus` model
 - make `ModelWithPublicStatusTest` for testing public status traits & interfaces
+
+
+## 2.5.0 - 2021-07-27
+- refactor `Model` class's `updated_for_humans` & `created_for_humans` attributes to `updated_diff_for_humans` & `created_diff_for_humans`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,4 @@ All notable changes to `models` will be documented in this file
 
 ## 2.5.0 - 2021-07-27
 - refactor `Model` class's `updated_for_humans` & `created_for_humans` attributes to `updated_diff_for_humans` & `created_diff_for_humans`
+- add 'created_for_humans' & 'updated_for_humans' attribute accessors to `Model` that display timestamps in a human-readable format ("F j, Y, g:i a" => "March 10, 2001, 5:16 pm")

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -225,7 +225,7 @@ abstract class Model extends EloquentModel
      */
     protected function getDatetimeForHumans(string $stringToTime): string
     {
-        return date('F j, Y', $stringToTime) . ' at ' . date('g:i a', $stringToTime);
+        return date('F j, Y', $stringToTime).' at '.date('g:i a', $stringToTime);
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -236,7 +236,7 @@ abstract class Model extends EloquentModel
      *
      * @return string
      */
-    public function getCreatedForHumansAttribute(): string
+    public function getCreatedDiffForHumansAttribute(): string
     {
         return $this->created_at->diffForHumans();
     }
@@ -280,7 +280,7 @@ abstract class Model extends EloquentModel
      *
      * @return string
      */
-    public function getUpdatedForHumansAttribute(): string
+    public function getUpdatedDiffForHumansAttribute(): string
     {
         return $this->updated_at->diffForHumans();
     }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -218,6 +218,17 @@ abstract class Model extends EloquentModel
     }
 
     /**
+     * Retrieve the 'timestampFormatForHumans' property.
+     *
+     * @param string $stringToTime
+     * @return string
+     */
+    protected function getDatetimeForHumans(string $stringToTime): string
+    {
+        return date('F j, Y', $stringToTime) . ' at ' . date('g:i a', $stringToTime);
+    }
+
+    /**
      * Retrieve the 'created_at' attribute mutated to human readable datetime.
      *
      * @return string
@@ -237,6 +248,18 @@ abstract class Model extends EloquentModel
     public function getCreatedTimestampAttribute(): string
     {
         return date($this->getTimestampFormat(), strtotime($this->created_at));
+    }
+
+    /**
+     * Retrieve the 'created_for_humans' attribute mutated to a timestamp for humans string.
+     *
+     *  - 'created_for_humans' attribute accessor
+     *
+     * @return string
+     */
+    public function getCreatedForHumansAttribute(): string
+    {
+        return $this->getDatetimeForHumans(strtotime($this->created_at));
     }
 
     /**
@@ -281,6 +304,18 @@ abstract class Model extends EloquentModel
     public function getUpdatedTimestampAttribute(): string
     {
         return date($this->getTimestampFormat(), strtotime($this->updated_at));
+    }
+
+    /**
+     * Retrieve the 'updated_for_humans' attribute mutated to a timestamp for humans string.
+     *
+     *  - 'updated_for_humans' attribute accessor
+     *
+     * @return string
+     */
+    public function getUpdatedForHumansAttribute(): string
+    {
+        return $this->getDatetimeForHumans(strtotime($this->updated_at));
     }
 
     /**

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -178,14 +178,14 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
-    public function getCreatedForHumansAttribute()
+    public function getCreatedDiffForHumansAttribute()
     {
         $expected = $this->model->created_at->diffForHumans();
-        $actual = $this->model->created_for_humans;
+        $actual = $this->model->created_diff_for_humans;
 
         $this->assertIsString($actual);
         $this->assertSame($expected, $actual);
-        $this->assertSame($actual, $this->model->getCreatedForHumansAttribute());
+        $this->assertSame($actual, $this->model->getCreatedDiffForHumansAttribute());
     }
 
     /** @test */
@@ -222,14 +222,14 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
-    public function getUpdatedForHumansAttribute()
+    public function getUpdatedDiffForHumansAttribute()
     {
         $expected = $this->model->updated_at->diffForHumans();
-        $actual = $this->model->updated_for_humans;
+        $actual = $this->model->updated_diff_for_humans;
 
         $this->assertIsString($actual);
         $this->assertSame($expected, $actual);
-        $this->assertSame($actual, $this->model->getUpdatedForHumansAttribute());
+        $this->assertSame($actual, $this->model->getUpdatedDiffForHumansAttribute());
     }
 
     /** @test */

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -180,7 +180,7 @@ class ModelTest extends ModelTestCase
     /** @test */
     public function getCreatedForHumansAttribute()
     {
-        $expected = date('F j, Y', strtotime($this->model->created_at)) . ' at ' . date('g:i a', strtotime($this->model->created_at));
+        $expected = date('F j, Y', strtotime($this->model->created_at)).' at '.date('g:i a', strtotime($this->model->created_at));
         $actual = $this->model->created_for_humans;
 
         $this->assertIsString($actual);
@@ -235,7 +235,7 @@ class ModelTest extends ModelTestCase
     /** @test */
     public function getUpdatedForHumansAttribute()
     {
-        $expected = date('F j, Y', strtotime($this->model->updated_at)) . ' at ' . date('g:i a', strtotime($this->model->updated_at));
+        $expected = date('F j, Y', strtotime($this->model->updated_at)).' at '.date('g:i a', strtotime($this->model->updated_at));
         $actual = $this->model->updated_for_humans;
 
         $this->assertIsString($actual);

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -178,6 +178,17 @@ class ModelTest extends ModelTestCase
     }
 
     /** @test */
+    public function getCreatedForHumansAttribute()
+    {
+        $expected = date('F j, Y', strtotime($this->model->created_at)) . ' at ' . date('g:i a', strtotime($this->model->created_at));
+        $actual = $this->model->created_for_humans;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getCreatedForHumansAttribute());
+    }
+
+    /** @test */
     public function getCreatedDiffForHumansAttribute()
     {
         $expected = $this->model->created_at->diffForHumans();
@@ -219,6 +230,17 @@ class ModelTest extends ModelTestCase
         $this->assertIsString($actual);
         $this->assertSame($expected, $actual);
         $this->assertSame($actual, $this->model->getUpdatedTimestampAttribute());
+    }
+
+    /** @test */
+    public function getUpdatedForHumansAttribute()
+    {
+        $expected = date('F j, Y', strtotime($this->model->updated_at)) . ' at ' . date('g:i a', strtotime($this->model->updated_at));
+        $actual = $this->model->updated_for_humans;
+
+        $this->assertIsString($actual);
+        $this->assertSame($expected, $actual);
+        $this->assertSame($actual, $this->model->getUpdatedForHumansAttribute());
     }
 
     /** @test */


### PR DESCRIPTION
- refactor `Model` class's `updated_for_humans` & `created_for_humans` attributes to `updated_diff_for_humans` & `created_diff_for_humans`
- add 'created_for_humans' & 'updated_for_humans' attribute accessors to `Model` that display timestamps in a human-readable format ("F j, Y, g:i a" => "March 10, 2001, 5:16 pm")