### PR TITLE
`Model::getDatetimeForHumans()` $stringToTime parameter type hinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,3 +135,7 @@ All notable changes to `models` will be documented in this file
 ## 2.5.0 - 2021-07-27
 - refactor `Model` class's `updated_for_humans` & `created_for_humans` attributes to `updated_diff_for_humans` & `created_diff_for_humans`
 - add 'created_for_humans' & 'updated_for_humans' attribute accessors to `Model` that display timestamps in a human-readable format ("F j, Y, g:i a" => "March 10, 2001, 5:16 pm")
+
+
+## 2.5.1 - 2021-07-27
+- fix issue with `Model::getDatetimeForHumans()` $stringToTime parameter type hinting

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -220,10 +220,10 @@ abstract class Model extends EloquentModel
     /**
      * Retrieve the 'timestampFormatForHumans' property.
      *
-     * @param string $stringToTime
+     * @param int $stringToTime
      * @return string
      */
-    protected function getDatetimeForHumans(string $stringToTime): string
+    protected function getDatetimeForHumans(int $stringToTime): string
     {
         return date('F j, Y', $stringToTime).' at '.date('g:i a', $stringToTime);
     }


### PR DESCRIPTION
- fix issue with `Model::getDatetimeForHumans()` $stringToTime parameter type hinting