### PR TITLE
`SoftDeletesIgnored` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,3 +139,7 @@ All notable changes to `models` will be documented in this file
 
 ## 2.5.1 - 2021-07-27
 - fix issue with `Model::getDatetimeForHumans()` $stringToTime parameter type hinting
+
+
+## 2.6.0 - 2021-07-28
+- make `SoftDeletesIgnored` trait for preventing the `SoftDeletesScope` from being applied to models (useful when `Sfneal\Models\Model` is needed but not soft deleting)

--- a/src/Models/Traits/SoftDeletesIgnored.php
+++ b/src/Models/Traits/SoftDeletesIgnored.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Models\Traits;
-
 
 trait SoftDeletesIgnored
 {
@@ -15,6 +13,5 @@ trait SoftDeletesIgnored
      */
     public static function bootSoftDeletes()
     {
-
     }
 }

--- a/src/Models/Traits/SoftDeletesIgnored.php
+++ b/src/Models/Traits/SoftDeletesIgnored.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Sfneal\Models\Traits;
+
+
+trait SoftDeletesIgnored
+{
+    // todo: add tests
+
+    /**
+     * Preventing booting the soft deleting trait for a model.
+     *
+     * @return void
+     */
+    public static function bootSoftDeletes()
+    {
+
+    }
+}


### PR DESCRIPTION
- make `SoftDeletesIgnored` trait for preventing the `SoftDeletesScope` from being applied to models (useful when `Sfneal\Models\Model` is needed but not soft deleting)