### PR TITLE
Cache keys convention change & sfneal/array-helpers dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,4 +151,5 @@ All notable changes to `models` will be documented in this file
  
 ## 2.6.2 - 2021-09-01
 - fix use of '#' cache key id suffix delimiter with ':'
+- add sfneal/array-helpers to composer dev requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,3 +148,7 @@ All notable changes to `models` will be documented in this file
 ## 2.6.1 - 2021-07-28
 - add `SoftDeletesIgnoredTest` for testing `SoftDeletesIgnored` trait
 
+ 
+## 2.6.2 - 2021-09-01
+- fix use of '#' cache key id suffix delimiter with ':'
+

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "laravel/legacy-factories": ">=1.1.0",
         "orchestra/testbench": ">=6.7",
         "phpunit/phpunit": ">=7.5.20",
+        "sfneal/array-helpers": "^3.0",
         "scrutinizer/ocular": "^1.8"
     },
     "autoload": {

--- a/src/Models/Traits/CacheableAll.php
+++ b/src/Models/Traits/CacheableAll.php
@@ -18,7 +18,7 @@ trait CacheableAll
     public static function all($columns = ['*'])
     {
         // todo: fix use of serializeHash() function
-        return Cache::rememberForever(parent::getTableName().':all#'.LaravelHelpers::serializeHash($columns),
+        return Cache::rememberForever(parent::getTableName().':all:'.LaravelHelpers::serializeHash($columns),
             function () use ($columns) {
                 return parent::all($columns);
             }

--- a/tests/Feature/Builders/WherePublicStatusTest.php
+++ b/tests/Feature/Builders/WherePublicStatusTest.php
@@ -20,7 +20,7 @@ class WherePublicStatusTest extends SeededTestCase
         $this->assertTrue($query instanceof PeopleBuilder);
 
         $this->assertTrue(
-            (new ArrayHelpers($query->pluck('public_status')->toArray()))->arrayValuesEqual($value)
+            ArrayHelpers::from($query->pluck('public_status')->toArray())->valuesEqual($value)
         );
     }
 


### PR DESCRIPTION
- fix use of '#' cache key id suffix delimiter with ':'
- add sfneal/array-helpers to composer dev requirements