### PR TITLE
Fix issues with Sqlite `QueryBuilder::ifStatement()` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,3 +165,7 @@ All notable changes to `models` will be documented in this file
 ## 2.8.0 - 2021-09-07
 - fix issues with use of `QueryBuilder::concatColumns()` method when using a 'Sqlite' database connection (added support for Sqlite concat syntax)
 - fix issues with use of `QueryBuilder::ifStatement()` method when using a 'Sqlite' database connection (added support for Sqlite concat syntax)
+
+
+## 2.8.1 - 2021-09-07
+- fix issue use of 'IFF' Sqlite function `QueryBuilder::ifStatement()` by replacing with use of 'CASE'

--- a/src/Builders/QueryBuilder.php
+++ b/src/Builders/QueryBuilder.php
@@ -95,7 +95,7 @@ class QueryBuilder extends EloquentBuilder
     {
         // Use Sqlite syntax
         if (DB::connection()->getDatabaseName() == ':memory:') {
-            return "iff({$condition}, {$expr_true}, {$expr_false})";
+            return "CASE WHEN {$condition} THEN {$expr_true} ELSE {$expr_false} END";
         }
 
         // Use standard syntax

--- a/tests/Assets/Builders/PeopleBuilder.php
+++ b/tests/Assets/Builders/PeopleBuilder.php
@@ -2,12 +2,51 @@
 
 namespace Sfneal\Models\Tests\Assets\Builders;
 
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Database\Query\Builder;
 use Sfneal\Builders\QueryBuilder;
 use Sfneal\Builders\Traits\WhereBetweenSplitter;
 use Sfneal\Builders\Traits\WherePublicStatus;
+use Sfneal\Models\Tests\Assets\Models\People;
 
 class PeopleBuilder extends QueryBuilder
 {
     use WhereBetweenSplitter;
     use WherePublicStatus;
+
+    /**
+     * @var EloquentModel|People
+     */
+    protected $targetModel = People::class;
+
+    /**
+     * UserBuilder constructor.
+     *
+     * @param Builder $query
+     */
+    public function __construct(Builder $query)
+    {
+        parent::__construct($query);
+        $this->setSelectRawJson();
+    }
+
+    /**
+     * Dynamically set the $selectRawJson.
+     *
+     * @return void
+     */
+    private function setSelectRawJson(): void
+    {
+        $this->selectRawJson = "{$this->tableName}.{$this->primaryKeyName} as id, {$this->concatName()} as text";
+    }
+
+    /**
+     * Retrieve the User model's 'name' attribute by concatenating first and last name columns.
+     *
+     * @return string
+     */
+    private function concatName(): string
+    {
+        return $this->concatColumns('name_first', 'name_last');
+    }
 }

--- a/tests/Feature/Builders/QueryBuilderTest.php
+++ b/tests/Feature/Builders/QueryBuilderTest.php
@@ -25,7 +25,7 @@ class QueryBuilderTest extends SeededTestCase
     public function selectRawJson()
     {
         $results = People::query()
-            ->selectRawJson('people.person_id as id, people.name_last as text')
+            ->selectRawJson()
             ->countAndPaginate();
 
         $this->assertSame($results['total_count'], 22);


### PR DESCRIPTION
- fix issue use of 'IFF' Sqlite function `QueryBuilder::ifStatement()` by replacing with use of 'CASE'