### PR TITLE
Laravel v11 support

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -27,11 +27,10 @@ jobs:
                     php-version: ${{ matrix.php }}
                     coverage: none
 
-            -   name: Install Composer Dependencies
-                run: |
-                    composer update --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
-
             -   name: Install Laravel
                 run: |
                     composer require "laravel/framework:^${{ matrix.laravel }}" --prefer-dist --no-interaction
 
+            -   name: Install Composer Dependencies
+                run: |
+                    composer update --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -2,7 +2,6 @@ name: Composer
 
 on:
     push:
-    pull_request:
 
 jobs:
     build:
@@ -12,7 +11,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.0, 8.1, 8.2, 8.3]
-                laravel: [8.0, 9.0, 10.0, 11.0]
+                laravel: ["8.0", "9.0", "10.0", "11.0"]
                 dependency-version: [prefer-lowest, prefer-stable]
                 dev-dependencies: [dev, no-dev]
 
@@ -34,5 +33,5 @@ jobs:
 
             -   name: Install Laravel
                 run: |
-                    composer require laravel/framework:^${{ matrix.laravel }} --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                    composer require "laravel/framework:^${{ matrix.laravel }}" --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -33,5 +33,5 @@ jobs:
 
             -   name: Install Laravel
                 run: |
-                    composer require "laravel/framework:^${{ matrix.laravel }}" --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                    composer require "laravel/framework:^${{ matrix.laravel }}" --prefer-dist --no-interaction
 

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -16,7 +16,7 @@ jobs:
                 dependency-version: [prefer-lowest, prefer-stable]
                 dev-dependencies: [dev, no-dev]
 
-        name: PHP ${{ matrix.php }} - Laravel v${{ matrix.dependency-version }} - ${{ matrix.dependency-version }} - ${{ matrix.dev-dependencies }}
+        name: PHP ${{ matrix.php }} - Laravel v${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.dev-dependencies }}
 
         steps:
             -   name: Checkout code
@@ -34,5 +34,5 @@ jobs:
 
             -   name: Install Laravel
                 run: |
-                    composer require laravel/framework:^${{ matrix.dev-dependencies }} --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                    composer require laravel/framework:^${{ matrix.laravel }} --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 

--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -12,10 +12,11 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.0, 8.1, 8.2, 8.3]
+                laravel: [8.0, 9.0, 10.0, 11.0]
                 dependency-version: [prefer-lowest, prefer-stable]
                 dev-dependencies: [dev, no-dev]
 
-        name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.dev-dependencies }}
+        name: PHP ${{ matrix.php }} - Laravel v${{ matrix.dependency-version }} - ${{ matrix.dependency-version }} - ${{ matrix.dev-dependencies }}
 
         steps:
             -   name: Checkout code
@@ -30,4 +31,8 @@ jobs:
             -   name: Install Composer Dependencies
                 run: |
                     composer update --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+            -   name: Install Laravel
+                run: |
+                    composer require laravel/framework:^${{ matrix.dev-dependencies }} --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,6 @@ name: Test Suite
 
 on:
     push:
-    pull_request:
-    release:
-        types: [published]
 
 jobs:
     test:
@@ -14,7 +11,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.0, 8.1, 8.2, 8.3]
-                laravel: [8.0, 9.0, 10.0, 11.0]
+                laravel: ["8.0", "9.0", "10.0", "11.0"]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: PHP ${{ matrix.php }} - Laravel v${{ matrix.laravel }} - ${{ matrix.dependency-version }}
@@ -35,7 +32,7 @@ jobs:
 
             -   name: Install Laravel
                 run: |
-                    composer require laravel/framework:^${{ matrix.laravel }} --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                    composer require "laravel/framework:^${{ matrix.laravel }}" --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests
                 run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,10 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.0, 8.1, 8.2, 8.3]
+                laravel: [8.0, 9.0, 10.0, 11.0]
                 dependency-version: [prefer-lowest, prefer-stable]
 
-        name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}
+        name: PHP ${{ matrix.php }} - Laravel v${{ matrix.dependency-version }} - ${{ matrix.dependency-version }}
 
         steps:
             -   name: Checkout code
@@ -31,6 +32,10 @@ jobs:
             -   name: Install Composer Dependencies
                 run: |
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+            -   name: Install Laravel
+                run: |
+                    composer require laravel/framework:^${{ matrix.dev-dependencies }} --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests
                 run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
             -   name: Install Laravel
                 run: |
-                    composer require "laravel/framework:^${{ matrix.laravel }}" --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                    composer require "laravel/framework:^${{ matrix.laravel }}" --prefer-dist --no-interaction
 
             -   name: Execute tests
                 run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,13 @@ jobs:
                     php-version: ${{ matrix.php }}
                     coverage: none
 
-            -   name: Install Composer Dependencies
-                run: |
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
-
             -   name: Install Laravel
                 run: |
                     composer require "laravel/framework:^${{ matrix.laravel }}" --prefer-dist --no-interaction
+
+            -   name: Install Composer Dependencies
+                run: |
+                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests
                 run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
                 laravel: [8.0, 9.0, 10.0, 11.0]
                 dependency-version: [prefer-lowest, prefer-stable]
 
-        name: PHP ${{ matrix.php }} - Laravel v${{ matrix.dependency-version }} - ${{ matrix.dependency-version }}
+        name: PHP ${{ matrix.php }} - Laravel v${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
         steps:
             -   name: Checkout code
@@ -35,7 +35,7 @@ jobs:
 
             -   name: Install Laravel
                 run: |
-                    composer require laravel/framework:^${{ matrix.dev-dependencies }} --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                    composer require laravel/framework:^${{ matrix.laravel }} --${{ matrix.dev-dependencies }} --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests
                 run: composer test

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "laravel/legacy-factories": ">=1.1.0",
         "orchestra/testbench": "^7.40|^8.0|9.0",
         "phpunit/phpunit": "^9.6|^10.0|^11.0",
-        "scrutinizer/ocular": "^1.8",
         "sfneal/array-helpers": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
- add support for Laravel v11
- add matrix to gh actions for testing versions 8 through 11 of laravel
- cut scrutinzer/ocular from composer requirements