### PR TITLE
phpunit v11 compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
+        "test": "vendor/bin/phpunit --testdox",
         "test-both": [
             "composer test",
             "composer docker-test"

--- a/tests/Feature/Builders/QueryBuilderTest.php
+++ b/tests/Feature/Builders/QueryBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Models\Tests\Feature\Builders;
 
-use Exception;
 use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Models\Tests\Assets\Models\People;
 use Sfneal\Models\Tests\SeededTestCase;
@@ -43,11 +42,7 @@ class QueryBuilderTest extends SeededTestCase
         $this->assertSame($output, $expected);
     }
 
-    /**
-     * @test
-     *
-     * @throws Exception
-     */
+    #[Test]
     public function getNextModel()
     {
         // Prevent randomly selecting the last item which has no 'next' model
@@ -61,11 +56,7 @@ class QueryBuilderTest extends SeededTestCase
         $this->assertSame($nextModel->person_id - 1, $model->person_id);
     }
 
-    /**
-     * @test
-     *
-     * @throws Exception
-     */
+    #[Test]
     public function getPreviousModel()
     {
         // Prevent randomly selecting the first model that doesn't have a 'previous' model

--- a/tests/Feature/Builders/QueryBuilderTest.php
+++ b/tests/Feature/Builders/QueryBuilderTest.php
@@ -3,12 +3,13 @@
 namespace Sfneal\Models\Tests\Feature\Builders;
 
 use Exception;
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Models\Tests\Assets\Models\People;
 use Sfneal\Models\Tests\SeededTestCase;
 
 class QueryBuilderTest extends SeededTestCase
 {
-    /** @test */
+    #[Test]
     public function getFlatArray()
     {
         $query = People::query();
@@ -21,7 +22,7 @@ class QueryBuilderTest extends SeededTestCase
         $this->assertSame($query->count('city'), count($array));
     }
 
-    /** @test */
+    #[Test]
     public function selectRawJson()
     {
         $results = People::query()
@@ -31,7 +32,7 @@ class QueryBuilderTest extends SeededTestCase
         $this->assertSame($results['total_count'], 22);
     }
 
-    /** @test */
+    #[Test]
     public function orderByCreatedAt()
     {
         $output = People::query()->orderByCreatedAt('desc')->get()->toArray();

--- a/tests/Feature/Builders/WhereBetweenSplitterTest.php
+++ b/tests/Feature/Builders/WhereBetweenSplitterTest.php
@@ -2,6 +2,8 @@
 
 namespace Sfneal\Models\Tests\Feature\Builders;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Builders\QueryBuilder;
 use Sfneal\Models\Tests\Assets\Builders\PeopleBuilder;
 use Sfneal\Models\Tests\Assets\Models\People;
@@ -33,11 +35,8 @@ class WhereBetweenSplitterTest extends SeededTestCase
         return $data;
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider ageRangeProvider
-     */
+    #[Test]
+    #[DataProvider('ageRangeProvider')]
     public function whereBetweenSplitter(int $min, int $max, $range)
     {
         $query = People::query()->whereBetweenSplitter('age', $range);

--- a/tests/Feature/Builders/WhereLikeTest.php
+++ b/tests/Feature/Builders/WhereLikeTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Models\Tests\Feature\Builders;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Builders\QueryBuilder;
 use Sfneal\Models\Tests\Assets\Builders\PeopleBuilder;
@@ -33,16 +34,8 @@ class WhereLikeTest extends SeededTestCase
         $this->assertTrue(in_array('Richard', $query->getFlatArray('name_first')));
     }
 
-    /**
-     * @test
-     *
-     * @dataProvider queryParamProvider
-     *
-     * @param  string  $column
-     * @param  $value
-     * @param  bool  $leadingWildcard
-     * @param  bool  $trailingWildcard
-     */
+    #[Test]
+    #[DataProvider('queryParamProvider')]
     public function whereLike(string $column, $value, bool $leadingWildcard = true, bool $trailingWildcard = true)
     {
         $query = People::query()->whereLike($column, $value, $leadingWildcard, $trailingWildcard);

--- a/tests/Feature/Builders/WhereLikeTest.php
+++ b/tests/Feature/Builders/WhereLikeTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Models\Tests\Feature\Builders;
 
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Builders\QueryBuilder;
 use Sfneal\Models\Tests\Assets\Builders\PeopleBuilder;
 use Sfneal\Models\Tests\Assets\Models\People;
@@ -48,7 +49,7 @@ class WhereLikeTest extends SeededTestCase
         $this->whereLikeAssertions($query);
     }
 
-    /** @test */
+    #[Test]
     public function orWhereLike()
     {
         // Basic usage
@@ -58,7 +59,7 @@ class WhereLikeTest extends SeededTestCase
         $this->whereLikeAssertions($query);
     }
 
-    /** @test */
+    #[Test]
     public function orWhereBool()
     {
         // Basic usage

--- a/tests/Feature/Builders/WherePublicStatusTest.php
+++ b/tests/Feature/Builders/WherePublicStatusTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Models\Tests\Feature\Builders;
 
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Builders\QueryBuilder;
 use Sfneal\Helpers\Arrays\ArrayHelpers;
 use Sfneal\Models\Tests\Assets\Builders\PeopleBuilder;
@@ -24,13 +25,13 @@ class WherePublicStatusTest extends SeededTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function wherePublic()
     {
         $this->executeAssertions(People::query()->wherePublic(), 1);
     }
 
-    /** @test */
+    #[Test]
     public function wherePrivate()
     {
         $this->executeAssertions(People::query()->wherePrivate(), 0);

--- a/tests/Feature/FactoryTest.php
+++ b/tests/Feature/FactoryTest.php
@@ -2,11 +2,12 @@
 
 namespace Sfneal\Models\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Models\Tests\ModelTestCase;
 
 class FactoryTest extends ModelTestCase
 {
-    /** @test */
+    #[Test]
     public function fillables_are_correct_types()
     {
         $this->assertIsString($this->model->name_first);
@@ -19,7 +20,7 @@ class FactoryTest extends ModelTestCase
         $this->assertIsString($this->model->zip);
     }
 
-    /** @test */
+    #[Test]
     public function attributes_are_correct_types()
     {
         // Age

--- a/tests/Feature/MigrationTest.php
+++ b/tests/Feature/MigrationTest.php
@@ -2,12 +2,13 @@
 
 namespace Sfneal\Models\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Models\Tests\Assets\Models\People;
 use Sfneal\Models\Tests\TestCase;
 
 class MigrationTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_can_access_the_database()
     {
         // Save a new Address

--- a/tests/Feature/Models/ModelWithPublicStatusTest.php
+++ b/tests/Feature/Models/ModelWithPublicStatusTest.php
@@ -2,12 +2,13 @@
 
 namespace Sfneal\Models\Tests\Feature\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Models\Tests\Assets\Models\People;
 use Sfneal\Models\Tests\SeededTestCase;
 
 class ModelWithPublicStatusTest extends SeededTestCase
 {
-    /** @test */
+    #[Test]
     public function isPublic()
     {
         People::query()
@@ -18,7 +19,7 @@ class ModelWithPublicStatusTest extends SeededTestCase
             });
     }
 
-    /** @test */
+    #[Test]
     public function isPrivate()
     {
         People::query()
@@ -29,7 +30,7 @@ class ModelWithPublicStatusTest extends SeededTestCase
             });
     }
 
-    /** @test */
+    #[Test]
     public function updatePublicStatus()
     {
         $model = People::factory()->create(['public_status' => null]);

--- a/tests/Feature/Models/SoftDeletesIgnoredTest.php
+++ b/tests/Feature/Models/SoftDeletesIgnoredTest.php
@@ -3,18 +3,19 @@
 namespace Sfneal\Models\Tests\Feature\Models;
 
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Models\Tests\Assets\Models\PeopleHard;
 use Sfneal\Models\Tests\SeededTestCase;
 
 class SoftDeletesIgnoredTest extends SeededTestCase
 {
-    /** @test */
+    #[Test]
     public function soft_deletes_scope_is_not_used()
     {
         $this->assertFalse(PeopleHard::hasGlobalScope(SoftDeletingScope::class));
     }
 
-    /** @test */
+    #[Test]
     public function deleted_at_attribute_does_not_exist()
     {
         $model = PeopleHard::factory()->create();

--- a/tests/Feature/ResolveModelNameTest.php
+++ b/tests/Feature/ResolveModelNameTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Models\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Models\Actions\ResolveModelName;
 use Sfneal\Models\Tests\Assets\Models\CompanyPeople;
 use Sfneal\Models\Tests\Assets\Models\People;
@@ -9,7 +10,7 @@ use Sfneal\Models\Tests\ModelTestCase;
 
 class ResolveModelNameTest extends ModelTestCase
 {
-    /** @test */
+    #[Test]
     public function resolvePeopleModelName()
     {
         $expected = 'People';
@@ -19,7 +20,7 @@ class ResolveModelNameTest extends ModelTestCase
         $this->assertEquals($expected, $output);
     }
 
-    /** @test */
+    #[Test]
     public function resolveClassModelName()
     {
         $expected = 'People';
@@ -29,7 +30,7 @@ class ResolveModelNameTest extends ModelTestCase
         $this->assertEquals($expected, $output);
     }
 
-    /** @test */
+    #[Test]
     public function resolveCompanyPeopleModelName()
     {
         $model = CompanyPeople::factory()->make();

--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -2,23 +2,24 @@
 
 namespace Sfneal\Models\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\Test;
 use Sfneal\Models\Tests\ModelTestCase;
 
 class ModelTest extends ModelTestCase
 {
-    /** @test */
+    #[Test]
     public function isNew()
     {
         $this->assertTrue($this->model->isNew());
     }
 
-    /** @test */
+    #[Test]
     public function howNew()
     {
         $this->assertIsFloat($this->model->howNew());
     }
 
-    /** @test */
+    #[Test]
     public function getIsNewColumn()
     {
         $expected = 'created_at';
@@ -28,7 +29,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function hasAttribute()
     {
         $this->assertTrue($this->model->hasAttribute('name_first'));
@@ -49,7 +50,7 @@ class ModelTest extends ModelTestCase
         $this->assertFalse($this->model->hasAttributeFillable('address_city'));
     }
 
-    /** @test */
+    #[Test]
     public function hasNullAttribute()
     {
         $this->assertFalse($this->model->hasNullAttribute('name_first'));
@@ -63,7 +64,7 @@ class ModelTest extends ModelTestCase
         $this->assertFalse($this->model->hasNullAttribute('public_status'));
     }
 
-    /** @test */
+    #[Test]
     public function getIdHashAttribute()
     {
         $expected = crc32($this->model->getKey());
@@ -74,14 +75,14 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->idHash());
     }
 
-    /** @test */
+    #[Test]
     public function getLabel()
     {
         $label = $this->model->getLabel();
         $this->assertSame($label, $this->model->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function getTableName()
     {
         $tableName = $this->model->getTableName();
@@ -89,7 +90,7 @@ class ModelTest extends ModelTestCase
         $this->assertTrue($tableName == 'people');
     }
 
-    /** @test */
+    #[Test]
     public function getPrimaryKeyName()
     {
         $primaryKey = $this->model->getPrimaryKeyName();
@@ -97,7 +98,7 @@ class ModelTest extends ModelTestCase
         $this->assertTrue($primaryKey == 'person_id');
     }
 
-    /** @test */
+    #[Test]
     public function wasCreated()
     {
         $actual = $this->model->wasCreated();
@@ -106,7 +107,7 @@ class ModelTest extends ModelTestCase
         $this->assertTrue($actual);
     }
 
-    /** @test */
+    #[Test]
     public function wasUpdated()
     {
         $notUpdated = $this->model->wasUpdated();
@@ -122,7 +123,7 @@ class ModelTest extends ModelTestCase
         $this->assertTrue($updated);
     }
 
-    /** @test */
+    #[Test]
     public function wasDeleted()
     {
         $notDeleted = $this->model->wasDeleted();
@@ -135,7 +136,7 @@ class ModelTest extends ModelTestCase
         $this->assertTrue($deleted);
     }
 
-    /** @test */
+    #[Test]
     public function mostRecentChange()
     {
         $expected = 'created';
@@ -145,7 +146,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function getDatetimeAttribute()
     {
         $expected = date('Y-m-d h:i a', strtotime($this->model->created_at));
@@ -156,7 +157,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->datetime());
     }
 
-    /** @test */
+    #[Test]
     public function getTimestampFormat()
     {
         $expected = 'Y-m-d h:i a';
@@ -166,7 +167,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function getCreatedTimestampAttribute()
     {
         $expected = date($this->model->getTimestampFormat(), strtotime($this->model->created_at));
@@ -177,7 +178,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->createdTimestamp());
     }
 
-    /** @test */
+    #[Test]
     public function getCreatedForHumansAttribute()
     {
         $expected = date('F j, Y', strtotime($this->model->created_at)).' at '.date('g:i a', strtotime($this->model->created_at));
@@ -188,7 +189,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->createdForHumans());
     }
 
-    /** @test */
+    #[Test]
     public function getCreatedDiffForHumansAttribute()
     {
         $expected = $this->model->created_at->diffForHumans();
@@ -199,7 +200,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->createdDiffForHumans());
     }
 
-    /** @test */
+    #[Test]
     public function getCreatedDateAttribute()
     {
         $expected = date('Y-m-d', strtotime($this->model->created_at));
@@ -210,7 +211,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->createdDate());
     }
 
-    /** @test */
+    #[Test]
     public function getCreatedTimeAttribute()
     {
         $expected = date('h:i A', strtotime($this->model->created_at));
@@ -221,7 +222,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->createdTime());
     }
 
-    /** @test */
+    #[Test]
     public function getUpdatedTimestampAttribute()
     {
         $expected = date($this->model->getTimestampFormat(), strtotime($this->model->updated_at));
@@ -232,7 +233,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->updatedTimestamp());
     }
 
-    /** @test */
+    #[Test]
     public function getUpdatedForHumansAttribute()
     {
         $expected = date('F j, Y', strtotime($this->model->updated_at)).' at '.date('g:i a', strtotime($this->model->updated_at));
@@ -243,7 +244,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->updatedForHumans());
     }
 
-    /** @test */
+    #[Test]
     public function getUpdatedDiffForHumansAttribute()
     {
         $expected = $this->model->updated_at->diffForHumans();
@@ -254,7 +255,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->updatedDiffForHumans());
     }
 
-    /** @test */
+    #[Test]
     public function getUpdatedDateAttribute()
     {
         $expected = date('Y-m-d', strtotime($this->model->updated_at));
@@ -265,7 +266,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->updatedDate());
     }
 
-    /** @test */
+    #[Test]
     public function getUpdatedTimeAttribute()
     {
         $expected = date('h:i A', strtotime($this->model->updated_at));
@@ -276,7 +277,7 @@ class ModelTest extends ModelTestCase
         $this->assertSame($actual, $this->model->updatedTime());
     }
 
-    /** @test */
+    #[Test]
     public function getUploadDirectory()
     {
         // todo: refactor to a trait test class


### PR DESCRIPTION
- remove use of phpdocs for declaring tests & data providers in test suite and replaced with use of phpunit attributes