### PR TITLE
Fix issues with use of `Model::hasAttribute()` method in Laravel v11 applications

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,8 +16,9 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php: [8.1, 8.2, 8.3]
+        dependency-version: [prefer-lowest, prefer-stable]
 
-    name: Static Analysis
+    name: Static Analysis | ${{ matrix.php }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -43,7 +44,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install composer dependencies
-        run: composer install
+        run: composer update --${{ matrix.dependency-version }}
 
       - name: Install Larastan
         run: composer require larastan/larastan:^2.0 --dev

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,7 +46,7 @@ jobs:
         run: composer install
 
       - name: Install Larastan
-        run: composer require nunomaduro/larastan:^2.0 --dev
+        run: composer require larastan/larastan:^2.0 --dev
 
       - name: Run Larastan static analysis
         run: ./vendor/bin/phpstan analyse --memory-limit=2G

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
 
 parameters:
 
@@ -9,7 +9,8 @@ parameters:
     # The level 9 is the highest level
     level: 1
 
-#    ignoreErrors:
-#        - '#PHPDoc tag @var#'
-
-    checkMissingIterableValueType: false
+    ignoreErrors:
+        -
+            message: '#Call to an undefined static method [a-zA-Z0-9\\_]+::hasAttribute\(\)#'
+            path: src/Models/Model.php
+            reportUnmatched: false

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -105,6 +105,7 @@ abstract class Model extends EloquentModel
     {
         // Laravel v11 added a `hasAttribute()` method, use parent method if available
         try {
+            // @phpstan-ignore-next-line
             return parent::hasAttribute($key);
         } catch (\BadMethodCallException $methodCallException) {
             return array_key_exists($key, $this->attributes);

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -103,8 +103,12 @@ abstract class Model extends EloquentModel
      */
     public function hasAttribute($key): bool
     {
-        // Determine that the attribute exists
-        return array_key_exists($key, $this->attributesToArray());
+        // Laravel v11 added a `hasAttribute()` method, use parent method if available
+        try {
+            return parent::hasAttribute($key);
+        } catch (\BadMethodCallException $methodCallException) {
+            return array_key_exists($key, $this->attributes);
+        }
     }
 
     /**
@@ -120,7 +124,7 @@ abstract class Model extends EloquentModel
     {
         // Determine that the attribute exists and weather it is fillable
         return
-            array_key_exists($key, $this->attributesToArray()) &&
+            $this->hasAttribute($key) &&
             in_array($key, $this->getFillable());
     }
 

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -105,7 +105,6 @@ abstract class Model extends EloquentModel
     {
         // Laravel v11 added a `hasAttribute()` method, use parent method if available
         try {
-            // @phpstan-ignore-next-line
             return parent::hasAttribute($key);
         } catch (\BadMethodCallException $methodCallException) {
             return array_key_exists($key, $this->attributes);

--- a/tests/ModelTestCase.php
+++ b/tests/ModelTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Models\Tests;
 
+use Illuminate\Support\Collection;
 use Sfneal\Models\Tests\Assets\Models\People;
 
 class ModelTestCase extends TestCase
@@ -21,5 +22,10 @@ class ModelTestCase extends TestCase
         parent::setUp();
 
         $this->model = People::factory()->create();
+    }
+
+    protected function resolvePhpUnitAnnotations(): Collection
+    {
+        return collect();
     }
 }


### PR DESCRIPTION
- add conditional use of `parent::hasAttribute()` when method exists